### PR TITLE
reload() was moved to importlib in Python 3

### DIFF
--- a/update.py
+++ b/update.py
@@ -134,8 +134,11 @@ def update_wordcloud_category():
     wordcloud.to_file('docs/png/wordcloud_category.png')
 
 if __name__ == '__main__':
-    reload(sys)
-    sys.setdefaultencoding('utf-8')
+    try:
+        reload(sys)  # Python 2
+        sys.setdefaultencoding('utf-8')
+    except NameError:
+        pass         # Python 3
 
     GANS = load_data()
     update_wordcloud_title()


### PR DESCRIPTION
__reload()__ was moved to importlib in Python 3 because it was being overused and led to issues that were difficult to debug.  This use seems to be focused on setting the default encoding to utf-8 which is already the default in Python 3 so this PR proposes that __pass__is sufficient.